### PR TITLE
don't use Zygote for zero-order algs

### DIFF
--- a/src/NonconvexNLopt.jl
+++ b/src/NonconvexNLopt.jl
@@ -15,6 +15,31 @@ struct NLoptAlg{L <: Union{Symbol, Nothing}} <: AbstractOptimizer
 end
 NLoptAlg(alg) = NLoptAlg(alg, nothing)
 
+function is_zero_order(algorithm, ::Nothing)
+    return algorithm in (
+        :GN_DIRECT,
+        :GN_DIRECT_L,
+        :GNL_DIRECT_NOSCAL,
+        :GN_DIRECT_L_NOSCAL,
+        :GN_DIRECT_L_RAND_NOSCAL,
+        :GN_ORIG_DIRECT,
+        :GN_ORIG_DIRECT_L,
+        :GN_CRS2_LM,
+        :GN_AGS,
+        :GN_ESCH,
+        :LN_COBYLA,
+        :LN_BOBYQA,
+        :LN_NEWUOA,
+        :LN_NEWUOA_BOUND,
+        :LN_PRAXIS,
+        :LN_NELDERMEAD,
+        :LN_SBPLX,
+    )
+end
+function is_zero_order(::Any, local_optimizer)
+    return is_zero_order(local_optimizer, nothing)
+end
+
 @params struct NLoptOptions
     nt::NamedTuple
 end
@@ -143,7 +168,7 @@ function get_nlopt_problem(algorithm, local_optimizer, options, obj, ineq_constr
             end
         end
     end
-    update_cached_values(x0)
+    update_cached_values(x0, !is_zero_order(algorithm, local_optimizer))
 
     function nlopt_obj(x, grad)
         if x == lastx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using NonconvexNLopt, LinearAlgebra, Test
 
-f(x::AbstractVector) = sqrt(x[2])
+f(x::AbstractVector) = x[2] >= 0 ? sqrt(x[2]) : Inf
 g(x::AbstractVector, a, b) = (a*x[1] + b)^3 - x[2]
 
 options = NLoptOptions(xtol_rel = 1e-4)


### PR DESCRIPTION
This PR fixes https://github.com/JuliaNonconvex/Nonconvex.jl/issues/160 by ensuring Zygote is never called when passing the problem to NLopt if a zero-order algorithm is input.