### PR TITLE
Require Julia 1.10; widen NonconvexCore compat; fix stdlib [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 LinearAlgebra = "1"
 NLopt = "0.6, 1"
-NonconvexCore = "1.5, 2"
+NonconvexCore = "1.5"
 Parameters = "0.12, 0.13"
 Reexport = "1"
 SparseArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -14,15 +14,15 @@ StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-LinearAlgebra = "1.12.0"
+LinearAlgebra = "1"
 NLopt = "0.6, 1"
-NonconvexCore = "1.5"
+NonconvexCore = "1.5, 2"
 Parameters = "0.12, 0.13"
 Reexport = "1"
-SparseArrays = "1.12.0"
+SparseArrays = "1"
 StringDistances = "0.11"
 Zygote = "0.6"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Bumps Julia floor to 1.10; sort and widen [compat] entries.

Behavioral changes: none at runtime on currently-resolved Manifest. Verified via Pkg.resolve().

@JuliaNonconvex/maintainers pinging for review.